### PR TITLE
Fix implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,29 @@
 PATH
   remote: .
   specs:
-    hash_serializer (0.1.1)
+    hash_serializer (0.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (4.2.6)
+      activesupport (= 4.2.6)
+      builder (~> 3.1)
+    activerecord (4.2.6)
+      activemodel (= 4.2.6)
+      activesupport (= 4.2.6)
+      arel (~> 6.0)
+    activerecord-nulldb-adapter (0.3.2)
+      activerecord (>= 2.0.0)
     activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    arel (6.0.3)
     ast (2.2.0)
+    builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
@@ -88,6 +99,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
+    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -99,6 +111,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord (~> 4.2.6)
+  activerecord-nulldb-adapter (~> 0.3.2)
   activesupport (~> 4.2, >= 4.2.4)
   bundler (~> 1.11)
   codeclimate-test-reporter (~> 0.4.8)
@@ -109,6 +123,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.39.0)
   simplecov (~> 0.11.2)
+  sqlite3 (~> 1.3.11)
   yard (~> 0.8.7.6)
 
 BUNDLED WITH

--- a/hash_serializer.gemspec
+++ b/hash_serializer.gemspec
@@ -30,4 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.39.0'
   spec.add_development_dependency 'simplecov', '~> 0.11.2'
   spec.add_development_dependency 'yard', '~> 0.8.7.6'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.11'
+  spec.add_development_dependency 'activerecord', '~> 4.2.6'
+  spec.add_development_dependency 'activerecord-nulldb-adapter', '~> 0.3.2'
 end

--- a/lib/hash_serializer/helpers.rb
+++ b/lib/hash_serializer/helpers.rb
@@ -1,88 +1,99 @@
+require 'active_support'
+
 module HashSerializer
   # Helper methods for generating methods from hash keys and validating keys
   module Helpers
-    # Validates a Postgres JSON hash on an ActiveRecord model does not include extra keys. It prevents user created
-    # data on JSON column types.
-    #
-    # Example:
-    #   >> validate_hash_serializer :billing_hash, %w(name address city state)
-    #
-    # @param hash_name [Symbol, String]
-    # @param valid_keys [Array]
-    #
-    # @return [Array] a sorted Array of the invalid keys
-    def validate_hash_serializer_keys(hash_name, valid_keys)
-      return if send(hash_name).nil? # || !send("#{hash_name}_changed?")
+    extend ActiveSupport::Concern
 
-      invalid_keys = send(hash_name).keys.map(&:to_s) - valid_keys.map(&:to_s)
-      return if invalid_keys.empty?
+    included do
+      # Validates a Postgres JSON hash on an ActiveRecord model does not include extra keys. It prevents user created
+      # data on JSON column types.
+      #
+      # Example:
+      #   >> validate_hash_serializer :billing_hash, %w(name address city state)
+      #
+      # @param hash_name [Symbol, String]
+      # @param valid_keys [Array]
+      #
+      # @return [Array] a sorted Array of the invalid keys
+      def validate_hash_serializer_keys(hash_name, valid_keys)
+        return if send(hash_name).nil? # || !send("#{hash_name}_changed?")
 
-      invalid_keys.sort
-    end
+        invalid_keys = send(hash_name).keys.map(&:to_s) - valid_keys.map(&:to_s)
+        return if invalid_keys.empty?
 
-    # Creates ActiveRecord model methods for a Postgres JSON hash
-    #
-    # Example:
-    #   >> store_accessor_with_prefix :stripe_oauth_fields, 'stripe_connect', VALID_STRIPE_OAUTH_FIELDS
-    #
-    # @param hash [Hash]
-    # @param prefix [String] prefix for the generated methods
-    # @param keys [Array] array of strings to create methods
-    def hash_accessor_with_prefix(hash, prefix, *keys)
-      Array(keys).flatten.each do |key|
-        prefixed_key = "#{prefix}_#{key}"
-
-        # Ex - billing_token=
-        create_setter_methods(hash, prefixed_key, key)
-
-        # Ex - billing_token
-        create_getters(hash, prefixed_key, key)
-
-        # Ex - billing_token_changed?
-        create_changed_methods(prefixed_key)
+        invalid_keys.sort
       end
     end
 
-    protected
+    # Helper methods available on the class
+    module ClassMethods
+      # Creates ActiveRecord model methods for a Postgres JSON hash
+      #
+      # Example:
+      #   >> hash_accessor_with_prefix :stripe_oauth_fields, 'stripe_connect', VALID_STRIPE_OAUTH_FIELDS
+      #
+      # @param hash_name [String | Symbol]
+      # @param prefix [String] prefix for the generated methods
+      # @param keys [Array] array of strings to create methods
+      def hash_accessor_with_prefix(hash_name, prefix, *keys)
+        Array(keys).flatten.each do |key|
+          prefixed_key = "#{prefix}_#{key}"
 
-    def create_method(name, &block)
-      self.class.send(:define_method, name, &block)
-    end
+          # Ex - billing_token=
+          create_setter_methods(hash_name, prefixed_key, key)
 
-    # Creates setter methods with the prefixed name and adds @*_changed properties, if the value changed,
-    # and calls [hash]_will_change! to signify the hash has updated
-    #
-    # @param hash [Hash]
-    # @param prefixed_key [String] the hash key with the desired prefix
-    # @param key [String] the non-prefixed hash key
-    def create_setter_methods(hash, prefixed_key, key)
-      create_method("#{prefixed_key}=") do |value|
-        # Set a variable to track whether the value changed
-        instance_variable_set("@#{prefixed_key}_changed", true) if send(hash)[key] != value
+          # Ex - billing_token
+          create_getters(hash_name, prefixed_key, key)
 
-        # Store the value
-        send(hash)[key] = value
-        send("#{hash}_will_change!") if respond_to? "#{hash}_will_change!".to_sym
+          # Ex - billing_token_changed?
+          create_changed_methods(prefixed_key)
+        end
       end
-    end
 
-    # Creates prefixed getter methods to access the hash value
-    #
-    # @param hash [Hash]
-    # @param prefixed_key [String] the hash key with the desired prefix
-    # @param key [String] the non-prefixed hash key
-    def create_getters(hash, prefixed_key, key)
-      create_method(prefixed_key) do
-        send(hash)[key]
+      private
+
+      def create_method(name, &block)
+        send(:define_method, name, &block)
       end
-    end
 
-    # Creates *_changed? methods referencing the @*_changed property created in create_setter_methods
-    #
-    # @param prefixed_key [String] the hash key with the desired prefix
-    def create_changed_methods(prefixed_key)
-      create_method("#{prefixed_key}_changed?") do
-        instance_variable_get("@#{prefixed_key}_changed") == true
+      protected
+
+      # Creates setter methods with the prefixed name and adds @*_changed properties, if the value changed,
+      # and calls [hash]_will_change! to signify the hash has updated
+      #
+      # @param hash_name [String | Symbol]
+      # @param prefixed_key [String] the hash key with the desired prefix
+      # @param key [String] the non-prefixed hash key
+      def create_setter_methods(hash_name, prefixed_key, key)
+        create_method("#{prefixed_key}=") do |value|
+          # Set a variable to track whether the value changed
+          instance_variable_set("@#{prefixed_key}_changed", true) if send(prefixed_key) != value
+
+          # Store the value
+          send(hash_name)[key] = value
+          send("#{hash_name}_will_change!") if respond_to? "#{hash_name}_will_change!".to_sym
+        end
+      end
+
+      # Creates prefixed getter methods to access the hash value
+      #
+      # @param hash_name [String | Symbol]
+      # @param prefixed_key [String] the hash key with the desired prefix
+      # @param key [String] the non-prefixed hash key
+      def create_getters(hash_name, prefixed_key, key)
+        create_method(prefixed_key) do
+          send(hash_name)[key]
+        end
+      end
+
+      # Creates *_changed? methods referencing the @*_changed property created in create_setter_methods
+      #
+      # @param prefixed_key [String] the hash key with the desired prefix
+      def create_changed_methods(prefixed_key)
+        create_method("#{prefixed_key}_changed?") do
+          instance_variable_get("@#{prefixed_key}_changed") == true
+        end
       end
     end
   end

--- a/lib/hash_serializer/version.rb
+++ b/lib/hash_serializer/version.rb
@@ -1,5 +1,5 @@
 # HashSerializer Version
 module HashSerializer
   # Current version
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -1,0 +1,24 @@
+require 'active_record'
+
+# Helper model for testing purposes
+class CustomerWithHash < ActiveRecord::Base
+  include HashSerializer::Helpers
+
+  VALID_KEYS = %w(name zipcode).freeze
+  INVALID_KEYS = %w(invalid keys).freeze
+  HASH_PREFIX = 'billing_stuff'.freeze
+
+  def initialize
+    super
+
+    @billing = {}
+  end
+
+  attr_writer(:billing)
+  attr_reader(:billing)
+
+  hash_accessor_with_prefix :billing, HASH_PREFIX, VALID_KEYS
+
+  def billing_will_change!
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,0 +1,9 @@
+require 'active_record'
+
+ActiveRecord::Schema.define do
+  self.verbose = false
+
+  create_table :customer_with_hashes, force: true do |t|
+    t.string :text
+  end
+end

--- a/spec/hash_serializer/helpers_spec.rb
+++ b/spec/hash_serializer/helpers_spec.rb
@@ -1,31 +1,9 @@
 require 'spec_helper'
 
-# Helper model for testing purposes
-class HelpersTestModel
-  include HashSerializer::Helpers
-
-  def initialize(hash = {})
-    @hash = hash
-  end
-
-  def billing=(hash)
-    @hash = hash
-  end
-
-  def billing
-    @hash
-  end
-
-  def billing_will_change!
-  end
-end
-
 describe HashSerializer::Helpers do
   let(:hash) { { name: 'John C. Bland II', zipcode: 78_377 } }
 
-  subject { HelpersTestModel.new }
-  let(:valid_keys) { %w(name zipcode) }
-  let(:invalid_keys) { %w(invalid keys) }
+  subject { CustomerWithHash.new }
 
   context 'validate_hash_serializer_keys' do
     it 'should return invalid keys' do
@@ -33,66 +11,46 @@ describe HashSerializer::Helpers do
       hash['keys'] = false
 
       subject.billing = hash
-      expect(subject.validate_hash_serializer_keys(:billing, valid_keys)).to eq(invalid_keys)
+
+      errors = subject.validate_hash_serializer_keys(:billing, CustomerWithHash::VALID_KEYS)
+
+      expect(errors).to eq(CustomerWithHash::INVALID_KEYS)
     end
 
     it 'should return nil if no invalid keys exist' do
-      expect(subject.validate_hash_serializer_keys(:billing, valid_keys)).to be_nil
+      expect(subject.validate_hash_serializer_keys(:billing, CustomerWithHash::VALID_KEYS)).to be_nil
     end
   end
 
   context 'hash_accessor_with_prefix' do
-    let(:prefix) { 'billing_stuff' }
-
-    context 'not called' do
-      it 'setters do not exist' do
-        expect(subject.respond_to?(:billing_stuff_name=)).to be_falsey
-        expect(subject.respond_to?(:billing_stuff_zipcode=)).to be_falsey
-      end
-
-      it 'getters do not exist' do
-        expect(subject.respond_to?(:billing_stuff_name)).to be_falsey
-        expect(subject.respond_to?(:billing_stuff_zipcode)).to be_falsey
-      end
-
-      it 'changed? methods exist' do
-        expect(subject.respond_to?(:billing_stuff_name_changed?)).to be_falsey
-        expect(subject.respond_to?(:billing_stuff_zipcode_changed?)).to be_falsey
-      end
+    it 'setters exist' do
+      expect(subject.respond_to?(:billing_stuff_name=)).to be_truthy
+      expect(subject.respond_to?(:billing_stuff_zipcode=)).to be_truthy
     end
 
-    context 'called' do
-      before(:each) { subject.hash_accessor_with_prefix(:billing, prefix, valid_keys) }
+    it 'getters exist' do
+      expect(subject.respond_to?(:billing_stuff_name)).to be_truthy
+      expect(subject.respond_to?(:billing_stuff_zipcode)).to be_truthy
+    end
 
-      it 'setters exist' do
-        expect(subject.respond_to?(:billing_stuff_name=)).to be_truthy
-        expect(subject.respond_to?(:billing_stuff_zipcode=)).to be_truthy
-      end
+    it 'changed? methods exist' do
+      expect(subject.respond_to?(:billing_stuff_name_changed?)).to be_truthy
+      expect(subject.respond_to?(:billing_stuff_zipcode_changed?)).to be_truthy
+    end
 
-      it 'getters exist' do
-        expect(subject.respond_to?(:billing_stuff_name)).to be_truthy
-        expect(subject.respond_to?(:billing_stuff_zipcode)).to be_truthy
-      end
+    it 'methods works' do
+      new_name = 'John Bland III'
+      new_zipcode = 85_008
 
-      it 'changed? methods exist' do
-        expect(subject.respond_to?(:billing_stuff_name_changed?)).to be_truthy
-        expect(subject.respond_to?(:billing_stuff_zipcode_changed?)).to be_truthy
-      end
+      expect(subject).to receive(:billing_will_change!).twice
 
-      it 'methods works' do
-        new_name = 'John Bland III'
-        new_zipcode = 85_008
+      subject.billing_stuff_name = new_name
+      subject.billing_stuff_zipcode = new_zipcode
 
-        expect(subject).to receive(:billing_will_change!).twice
-
-        subject.billing_stuff_name = new_name
-        subject.billing_stuff_zipcode = new_zipcode
-
-        expect(subject.billing_stuff_name).to eq(new_name)
-        expect(subject.billing_stuff_name_changed?).to be_truthy
-        expect(subject.billing_stuff_zipcode).to eq(new_zipcode)
-        expect(subject.billing_stuff_zipcode_changed?).to be_truthy
-      end
+      expect(subject.billing_stuff_name).to eq(new_name)
+      expect(subject.billing_stuff_name_changed?).to be_truthy
+      expect(subject.billing_stuff_zipcode).to eq(new_zipcode)
+      expect(subject.billing_stuff_zipcode_changed?).to be_truthy
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'active_record'
 
 SimpleCov.start
 SimpleCov.minimum_coverage 99
@@ -11,3 +12,10 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'hash_serializer'
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
+                                        database: ':memory:',
+                                        schema: 'spec/db/schema.rb')
+
+load 'db/schema.rb'
+require 'db/models.rb'


### PR DESCRIPTION
The implementation didn't work as expected once used to replace the original implementation in a project. It wasn't as easy to tie things in.
### Changes

This update gets away from the generic implementation and goes straight for a `Concern` implementation.
### Testing

This was verified in a production repository and all tests are passing.

FYA: @johncblandii
